### PR TITLE
Add path to the docker build command

### DIFF
--- a/docs/content/howto/image_redhat_certification.md
+++ b/docs/content/howto/image_redhat_certification.md
@@ -96,7 +96,7 @@ ENTRYPOINT ["/manager"]
 4. Build and push image to image registry:
 
 ```bash
-$ docker build -t example-app:v0.0.1
+$ docker build -t example-app:v0.0.1 .
 
 $ docker push YOUR-USER-NAME/example-app:v0.0.1
 ```


### PR DESCRIPTION
Add missing path to the `docker build` command.

Fixes following error:

$ docker build -t example-app:v0.0.1
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -
